### PR TITLE
[BugFix] Add google repository to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        google()
         jcenter()
         maven { url 'https://maven.google.com' }
     }
@@ -27,6 +28,7 @@ android {
 }
 
 repositories {
+    google()
     jcenter()
     maven { url 'https://maven.google.com' }
 }


### PR DESCRIPTION
This update fixes the error below when building.

```
A problem occurred configuring project ':react-native-apk-installer-n'.
> Could not resolve all files for configuration ':react-native-apk-installer-n:classpath'.
   > Could not find intellij-core.jar (com.android.tools.external.com-intellij:intellij-core:26.0.1).
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/external/com-intellij/intellij-core/26.0.1/intellij-core-26.0.1.jar
```